### PR TITLE
[ADD] d_c_website_sale: Reminder for abandoned carts

### DIFF
--- a/distribution_circuits_website_sale/README.md
+++ b/distribution_circuits_website_sale/README.md
@@ -1,0 +1,15 @@
+Distribution Circuits in E-Commerce
+===================================
+
+
+Configuration
+-------------
+
+To enable reminders for users who abandoned a carts to be send :
+
+1. Activate "developper mode"
+1. Go Settings > Technical > Automation > Scheduled Actions
+1. Activate the "Send Email for Abandoned Cart Before Timeframe End"
+
+Delay before which reminders should be send is configurable in the
+Website Settings.

--- a/distribution_circuits_website_sale/__manifest__.py
+++ b/distribution_circuits_website_sale/__manifest__.py
@@ -13,17 +13,21 @@
                 'portal',
                 'website_sale',
                 'website_payment',
-                'auth_signup'
+                'auth_signup',
+                'mail',
                 ],
     "description": """
     This module implements the e-commerce features manage the sales
     of your distribution circuits.
     """,
     'data': [
+        "data/cron.xml",
+        "data/mail_templates.xml",
         "security/ir.model.access.csv",
         "views/website_sale_template.xml",
         "views/website_portal_sale_template.xml",
         "views/auth_signup_template.xml",
+        "views/res_config_settings_views.xml",
         "views/res_users_view.xml",
     ],
     'installable': True,

--- a/distribution_circuits_website_sale/data/cron.xml
+++ b/distribution_circuits_website_sale/data/cron.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2018 Coop IT Easy SCRLfs
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo noupdate="1">
+  <record id="ir_cron_abandoned_cart_reminder_before_timeframe_end"
+          model="ir.cron">
+    <field name="name">
+      Send Email for Abandoned Cart Before Timeframe End
+    </field>
+    <field name="interval_number">1</field>
+    <field name="interval_type">days</field>
+    <field name="numbercall">-1</field>
+    <field name="model_id" ref="model_sale_order"/>
+    <field name="state">code</field>
+    <field name="code">
+      model._cron_send_mail_before_timeframe_end()
+    </field>
+    <field name="active" eval="False"/>
+  </record>
+</odoo>

--- a/distribution_circuits_website_sale/data/mail_templates.xml
+++ b/distribution_circuits_website_sale/data/mail_templates.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2018 Coop IT Easy SCRLfs
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+  <data noupdate="1">
+    <record id="mail_template_sale_cart_timeframe_recovery"
+            model="mail.template">
+      <field name="name">eCommerce: Cart Time Frame Recovery Email</field>
+      <field name="email_from">${(object.user_id.email or '')|safe}</field>
+      <field name="subject">You left items in your cart</field>
+      <field name="partner_to">${object.partner_id.id}</field>
+      <field name="model_id" ref="sale.model_sale_order"/>
+      <field name="auto_delete" eval="True"/>
+      <field name="lang">${object.partner_id.lang}</field>
+      <field name="body_html" type="xml">
+        <div style="margin:auto;width:100%;">
+          <img src="/web/image/res.company/${user.company_id.id}/logo"
+               style="height: auto; width: 80px; margin-top:30px;"
+               alt="${user.company_id.name}"/>
+          <h1 style="color:#A9A9A9;">THERE'S SOMETHING IN YOUR CART.</h1>
+          <p>Would you like to complete your purchase?</p><br/><br/>
+          % if object.order_line:
+            % for line in object.order_line:
+            <hr/>
+            <table width="100%">
+              <tr>
+                <td style="padding: 10px; width:150px;">
+                  <img
+                    src="/web/image/product.product/${line.product_id.id}/image"
+                    height="100px" width="100px"/>
+                </td>
+                <td>
+                  <strong>${line.product_id.display_name}</strong><br/>
+                  ${line.name}
+                </td>
+                <td width="100px" align="right">
+                  ${(line.product_uom_qty) | int} ${(line.product_uom.name)}
+                </td>
+              </tr>
+            </table>
+            % endfor
+            <hr/>
+          % endif
+          <br/><br/>
+          <center>
+            <a href="/shop/cart?access_token=${object.access_token}"
+               target="_blank"
+               style="background-color: #1abc9c;
+                      padding: 20px;
+                      text-decoration: none;
+                      color: #fff;
+                      border-radius: 5px;
+                      font-size: 16px;"
+               class="o_default_snippet_text">
+               Resume order
+             </a><br/><br/><br/>
+            <p><b>Thank you for shopping with ${user.company_id.name}!</b></p>
+          </center>
+        </div>
+      </field>
+    </record>
+  </data>
+</odoo>

--- a/distribution_circuits_website_sale/models/__init__.py
+++ b/distribution_circuits_website_sale/models/__init__.py
@@ -1,2 +1,4 @@
-from . import website
+from . import res_config_settings
 from . import res_users
+from . import sale_order
+from . import website

--- a/distribution_circuits_website_sale/models/res_config_settings.py
+++ b/distribution_circuits_website_sale/models/res_config_settings.py
@@ -1,0 +1,44 @@
+# Copyright 2018 Coop IT Easy SCRLfs
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from ast import literal_eval
+
+from odoo import api, models, fields
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    cart_abandoned_before_timeframe_end_delay = fields.Float(
+        "Delay Before End of Time Frame",
+        default=24.0,
+        help="Number of hours before the end of the time frame when a "
+             "reminder is sent",
+    )
+
+    @api.model
+    def get_values(self):
+        res = super(ResConfigSettings, self).get_values()
+        param_mgr = self.env['ir.config_parameter']
+
+        cart_delay = float(
+            param_mgr.sudo().get_param(
+                'distribution_circuits_sale'
+                '.cart_abandoned_before_timeframe_end_delay',
+                default='24.0'
+            )
+        )
+
+        res.update(
+            cart_abandoned_before_timeframe_end_delay=cart_delay,
+        )
+        return res
+
+    def set_values(self):
+        super(ResConfigSettings, self).set_values()
+        param_mgr = self.env['ir.config_parameter']
+        param_mgr.sudo().set_param(
+            'distribution_circuits_sale'
+            '.cart_abandoned_before_timeframe_end_delay',
+            self.cart_abandoned_before_timeframe_end_delay
+        )

--- a/distribution_circuits_website_sale/models/sale_order.py
+++ b/distribution_circuits_website_sale/models/sale_order.py
@@ -1,0 +1,71 @@
+# Copyright 2018 Coop IT Easy SCRLfs
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import datetime
+
+from ast import literal_eval
+
+from odoo import api, models, fields
+from odoo.osv import expression
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    is_abandoned_cart_near_timeframe_end = fields.Boolean(
+        'Is Abandoned Cart Near Timeframe End',
+        compute='_compute_abandoned_cart_near_timeframe_end',
+        search='_search_abandoned_cart_near_timeframe_end',
+    )
+    cart_reminder_email_before_timeframe_end_sent = fields.Boolean(
+        'Cart reminder email before timeframe end already sent'
+    )
+
+    @api.multi
+    @api.depends('team_id.team_type', 'date_order', 'order_line',
+                 'state', 'partner_id')
+    def _compute_abandoned_cart_near_timeframe_end(self):
+        delay = float(
+            self.env['ir.config_parameter'].sudo()
+            .get_param('distribution_circuits_sale'
+                       '.cart_abandoned_before_timeframe_end_delay')
+        )
+        timeframe_end = fields.Datetime.to_string(
+            datetime.datetime.utcnow() + datetime.timedelta(hours=delay)
+        )
+        for order in self:
+            order.is_abandoned_cart_near_timeframe_end = bool(
+                order.time_frame_id.end <= timeframe_end
+                and order.is_abandoned_cart
+            )
+
+    def _search_abandoned_cart_near_timeframe_end(self, operator, value):
+        delay = float(
+            self.env['ir.config_parameter'].sudo()
+            .get_param('distribution_circuits_sale'
+                       '.cart_abandoned_before_timeframe_end_delay')
+        )
+        timeframe_end = fields.Datetime.to_string(
+            datetime.datetime.utcnow() + datetime.timedelta(hours=delay)
+        )
+        domain = expression.normalize_domain([
+            ('time_frame_id.end', '<=', timeframe_end),
+            ('is_abandoned_cart', operator, bool(value)),
+        ])
+        return domain
+
+    @api.model
+    def _cron_send_mail_before_timeframe_end(self):
+        mail_mgr = self.env['mail.template']
+        orders = self.env['sale.order'].search([
+            ('is_abandoned_cart_near_timeframe_end', '=', True)
+        ])
+        mail_template = self.env.ref(
+            'distribution_circuits_sale'
+            '.cart_reminder_mail_before_timeframe_end'
+        )
+        for order in orders:
+            order.cart_reminder_email_before_timeframe_end_sent = (
+                mail_mgr.browse(mail_template.id).send(order.id)
+            )
+        return True

--- a/distribution_circuits_website_sale/views/res_config_settings_views.xml
+++ b/distribution_circuits_website_sale/views/res_config_settings_views.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2018 Coop IT Easy SCRLfs
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+  <record id="res_config_settings_view_form_distrib" model="ir.ui.view">
+    <field name="name">
+      res.config.settings.view.form.inherit.website.sale.distribution.circuits
+    </field>
+    <field name="model">res.config.settings</field>
+    <field name="inherit_id" ref="website_sale.res_config_settings_view_form"/>
+    <field name="arch" type="xml">
+      <xpath expr="//div[@id='sale_checkout_settings']" position="inside">
+
+        <div id="timeframe_abandoned_cart_reminder"
+          class="col-xs-12 col-md-6 o_setting_box"
+          title="Send a reminder email to authenticated shoppers">
+
+          <div class="o_setting_left_pane"/>
+
+          <div class="o_setting_right_pane">
+            <label string="Email for abandoned carts near a timeframe end"/>
+            <div class="text-muted">
+              Default recovery email to send when a cart is abandoned
+              and that the end of a timeframe is comming.
+            </div>
+            <div class="content-group">
+              <div class="row mt16">
+                <label for="cart_abandoned_before_timeframe_end_delay"
+                  class="col-md-3 o_light_label"/>
+                <span class="col-md-3">
+                  <field name="cart_abandoned_before_timeframe_end_delay"/>hours
+                </span>
+              </div>
+            </div>
+          </div>
+
+        </div>
+
+      </xpath>
+    </field>
+  </record>
+</odoo>


### PR DESCRIPTION
Add functionality to send email to the owners of abandoned carts before
the end of a time frame.

In the website configuration, this adds  the number of hours before the
end of a time frame that have to be taken into account to send the
reminder email.

This also adds a cron that check if there are abandoned carts each days.