### PR TITLE
[FIX] Supplier name on website

### DIFF
--- a/distribution_circuits_website_sale/views/website_sale_template.xml
+++ b/distribution_circuits_website_sale/views/website_sale_template.xml
@@ -102,7 +102,7 @@
 	
 	<template id="short_distri_product_quantity" inherit_id="website_sale.product_quantity" customize_show="True" name="Select Quantity">
 		<xpath expr="//h1[@t-field='product.name']" position="after">
-        	<strong><t t-esc="product.display_name"/></strong><br/>
+        	<strong><t t-esc="product.sudo().supplier_id.display_name"/></strong><br/>
         	<strong>
         		<t t-esc="int(product.weight)"/>
         		<t t-esc="product.uom_name"/>
@@ -119,7 +119,7 @@
 					<t t-esc="product.uom_name"/>)
 					</strong>
 			</h5>
-			<h5><strong><t t-esc="product.display_name"/></strong></h5>
+			<h5><strong><t t-esc="product.sudo().supplier_id.display_name"/></strong></h5>
 		</xpath>
 	</template>	
 


### PR DESCRIPTION
This fix aims at displaying the supplier's name under the name of a product on the website.

I tested without sudo(), but got an internal server error for public users.